### PR TITLE
Add fastAPI POST end point to insert new rows and new id data type to autoincrement

### DIFF
--- a/fastapi-app/main.py
+++ b/fastapi-app/main.py
@@ -2,9 +2,13 @@ from fastapi import FastAPI, HTTPException, Depends
 from models.request import InsertRequest
 from models.response import InsertResponse
 import asyncpg
-import os
 import traceback
 from datetime import datetime
+from dotenv import load_dotenv
+import os
+
+env_path = os.path.join(os.path.dirname(__file__), "..", ".env")
+load_dotenv(env_path)
 
 app = FastAPI()
 

--- a/fastapi-app/main.py
+++ b/fastapi-app/main.py
@@ -1,7 +1,94 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, Depends
+from models.request import InsertRequest
+from models.response import InsertResponse
+import asyncpg
+import os
+import traceback
+from datetime import datetime
 
 app = FastAPI()
 
+# Database Connection Settings
+DB_HOST = os.getenv("DB_HOST")
+DB_NAME = os.getenv("DB_NAME")
+DB_USER = os.getenv("DB_USER")
+DB_PASSWORD = os.getenv("DB_PASSWORD")
+
+# Dependency: Get Database Connection (Auto-Close After Request)
+
+
+async def get_db():
+    conn = await asyncpg.connect(
+        host=DB_HOST, database=DB_NAME, user=DB_USER, password=DB_PASSWORD
+    )
+    try:
+        yield conn
+    finally:
+        await conn.close()
+
+TABLE_SCHEMAS = {
+    "departments": ["department"],
+    "jobs": ["job"],
+    "hired_employees": ["name", "hire_datetime", "department_id", "job_id"],
+}
+
+
+@app.post("/insert", response_model=InsertResponse)
+async def insert_data(request: InsertRequest, db=Depends(get_db)):
+    try:
+        if request.table not in TABLE_SCHEMAS:
+            raise HTTPException(status_code=400, detail="Invalid table name")
+
+        required_fields = TABLE_SCHEMAS[request.table]
+        valid_records = []
+        failed_records = []
+
+        async with db.transaction():  # SOne transaction for all inserts
+            for record in request.data:
+                if not all(field in record for field in required_fields):
+                    failed_records.append(record)
+                    continue
+
+                # Validate `department_id` and `job_id` for `hired_employees`
+                if request.table == "hired_employees":
+                    try:
+                        record["hire_datetime"] = datetime.fromisoformat(
+                            record["hire_datetime"].replace("Z", "+00:00"))
+                    except ValueError:
+                        failed_records.append(record)
+                        continue
+
+                    dep_exists = await db.fetchval("SELECT COUNT(*) FROM departments WHERE id = $1", record["department_id"])
+                    job_exists = await db.fetchval("SELECT COUNT(*) FROM jobs WHERE id = $1", record["job_id"])
+
+                    if dep_exists == 0 or job_exists == 0:
+                        failed_records.append(record)
+                        continue
+
+                valid_records.append(record)
+
+            if valid_records:
+                for record in valid_records:
+                    columns = ", ".join(required_fields)
+                    values_placeholders = ", ".join(
+                        f"${i+1}" for i in range(len(required_fields)))
+                    sql_query = f"INSERT INTO {request.table} ({columns}) VALUES ({values_placeholders}) RETURNING id"
+                    inserted_id = await db.fetchval(sql_query, *tuple(record[field] for field in required_fields))
+
+                    print(f"Inserted record with ID: {inserted_id}")
+
+        return {
+            "success": True if valid_records else False,
+            "message": f"{len(valid_records)} records inserted into {request.table}",
+            "failed_records": failed_records
+        }
+
+    except Exception as e:
+        error_message = f"Internal Server Error: {str(e)}\n{traceback.format_exc()}"
+        print(error_message)
+        raise HTTPException(status_code=500, detail=error_message)
+
+
 @app.get("/")
 def home():
-    return {"message": "FastAPI on EC2 is working!"}
+    return {"message": "FastAPI on EC2 is working yes sir!"}

--- a/fastapi-app/models/departments.py
+++ b/fastapi-app/models/departments.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel, Field
+
+
+class DepartmentInsert(BaseModel):
+    id: int = Field(..., example=1)
+    department: str = Field(..., example="Engineering")

--- a/fastapi-app/models/employees.py
+++ b/fastapi-app/models/employees.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel, Field
+from datetime import datetime
+
+
+class HiredEmployeeInsert(BaseModel):
+    id: int = Field(..., example=1)
+    name: str = Field(..., example="John Doe")
+    hire_datetime: datetime = Field(..., example="2021-05-15T14:30:00Z")
+    department_id: int = Field(..., example=2)
+    job_id: int = Field(..., example=3)

--- a/fastapi-app/models/jobs.py
+++ b/fastapi-app/models/jobs.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel, Field
+
+
+class JobInsert(BaseModel):
+    id: int = Field(..., example=1)
+    job: str = Field(..., example="Software Engineer")

--- a/fastapi-app/models/request.py
+++ b/fastapi-app/models/request.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel, Field
+from typing import List
+
+
+class InsertRequest(BaseModel):
+    table: str = Field(..., example="hired_employees")
+    data: List[dict]  # Raw data, validated dynamically

--- a/fastapi-app/models/response.py
+++ b/fastapi-app/models/response.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel, Field
+from typing import List
+
+
+class InsertResponse(BaseModel):
+    success: bool = Field(..., example=True)
+    message: str = Field(...,
+                         example="10 records inserted into hired_employees")
+    failed_records: List[dict] = Field(..., example=[])

--- a/fastapi-app/requirements.txt
+++ b/fastapi-app/requirements.txt
@@ -1,5 +1,7 @@
 annotated-types==0.7.0
 anyio==4.5.2
+async-timeout==5.0.1
+asyncpg==0.30.0
 boto3==1.36.18
 botocore==1.36.18
 click==8.1.8

--- a/scripts/migration/migrate_csv_to_postgres.py
+++ b/scripts/migration/migrate_csv_to_postgres.py
@@ -5,6 +5,12 @@ import io
 import os
 import logging
 import watchtower
+from dotenv import load_dotenv
+import os
+
+env_path = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), "..", "..", ".env"))
+load_dotenv(env_path)
 
 # AWS Configuration
 S3_BUCKET = "data-pipeline-migration-gb"

--- a/scripts/sql/alter_id_schemas.sql
+++ b/scripts/sql/alter_id_schemas.sql
@@ -1,0 +1,14 @@
+-- Create a sequence for each table starting in the last id +1 after the migration
+CREATE SEQUENCE IF NOT EXISTS departments_id_seq START WITH 13;
+CREATE SEQUENCE IF NOT EXISTS jobs_id_seq START WITH 184;
+CREATE SEQUENCE IF NOT EXISTS hired_employees_id_seq START WITH 2000;
+
+-- Link the sequence to the `id` column
+ALTER TABLE departments ALTER COLUMN id SET DEFAULT nextval('departments_id_seq');
+ALTER TABLE jobs ALTER COLUMN id SET DEFAULT nextval('jobs_id_seq');
+ALTER TABLE hired_employees ALTER COLUMN id SET DEFAULT nextval('hired_employees_id_seq');
+
+-- Ensure the sequences start from the next available ID
+SELECT setval('departments_id_seq', (SELECT MAX(id) FROM departments));
+SELECT setval('jobs_id_seq', (SELECT MAX(id) FROM jobs));
+SELECT setval('hired_employees_id_seq', (SELECT MAX(id) FROM hired_employees));


### PR DESCRIPTION
This is to add the new POST endpoint to insert new data from all the tables using only one service. This contains the following conditions:

Create a Rest API service to receive new data. This service must have:

- [x] 2.1. Each new transaction must fit the data dictionary rules. 
- [x] 2.2. Be able to insert batch transactions (1 up to 1000 rows) with one request.
- [x] 2.3. Receive the data for each table in the same service.
- [x] 2.4. Keep in mind the data rules for each table.

Also this add a small change in the tables schema, changing the id type to auto-increment when inserting new data